### PR TITLE
test.py  always override env when executing scylla subprocess

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -4534,7 +4534,7 @@ static lw_shared_ptr<keyspace_metadata> create_keyspace_metadata(std::string_vie
         initial_tablets = std::stol(tags_map.at(INITIAL_TABLETS_TAG_KEY));
     }
 
-    return keyspace_metadata::new_keyspace(keyspace_name, "org.apache.cassandra.locator.NetworkTopologyStrategy", std::move(opts), initial_tablets, true);
+    return keyspace_metadata::new_keyspace(keyspace_name, "org.apache.cassandra.locator.NetworkTopologyStrategy", std::move(opts), initial_tablets);
 }
 
 future<> executor::start() {

--- a/auth/service.cc
+++ b/auth/service.cc
@@ -180,8 +180,7 @@ future<> service::create_keyspace_if_missing(::service::migration_manager& mm) c
                     meta::AUTH_KS,
                     "org.apache.cassandra.locator.SimpleStrategy",
                     opts,
-                    std::nullopt,
-                    true);
+                    std::nullopt);
 
             try {
                 co_return co_await mm.announce(::service::prepare_new_keyspace_announcement(db.real_database(), ksm, ts),

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -123,7 +123,7 @@ lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata(s
     std::optional<unsigned> initial_tablets;
     auto options = prepare_options(sc, tm, get_replication_options(), initial_tablets);
     return data_dictionary::keyspace_metadata::new_keyspace(ks_name, sc,
-            std::move(options), initial_tablets, get_boolean(KW_DURABLE_WRITES, true), std::vector<schema_ptr>{}, get_storage_options());
+            std::move(options), initial_tablets, get_boolean(KW_DURABLE_WRITES, true), get_storage_options());
 }
 
 lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata_update(lw_shared_ptr<data_dictionary::keyspace_metadata> old, const locator::token_metadata& tm) {
@@ -139,7 +139,7 @@ lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata_u
         initial_tablets = old->initial_tablets();
     }
 
-    return data_dictionary::keyspace_metadata::new_keyspace(old->name(), *sc, options, initial_tablets, get_boolean(KW_DURABLE_WRITES, true), std::vector<schema_ptr>{}, get_storage_options());
+    return data_dictionary::keyspace_metadata::new_keyspace(old->name(), *sc, options, initial_tablets, get_boolean(KW_DURABLE_WRITES, true), get_storage_options());
 }
 
 

--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -203,36 +203,6 @@ keyspace_metadata::keyspace_metadata(std::string_view name,
              locator::replication_strategy_config_options strategy_options,
              std::optional<unsigned> initial_tablets,
              bool durable_writes,
-             std::vector<schema_ptr> cf_defs)
-    : keyspace_metadata(name,
-                        strategy_name,
-                        std::move(strategy_options),
-                        initial_tablets,
-                        durable_writes,
-                        std::move(cf_defs),
-                        user_types_metadata{}) { }
-
-keyspace_metadata::keyspace_metadata(std::string_view name,
-             std::string_view strategy_name,
-             locator::replication_strategy_config_options strategy_options,
-             std::optional<unsigned> initial_tablets,
-             bool durable_writes,
-             std::vector<schema_ptr> cf_defs,
-             user_types_metadata user_types)
-    : keyspace_metadata(name,
-                        strategy_name,
-                        std::move(strategy_options),
-                        initial_tablets,
-                        durable_writes,
-                        std::move(cf_defs),
-                        std::move(user_types),
-                        storage_options{}) { }
-
-keyspace_metadata::keyspace_metadata(std::string_view name,
-             std::string_view strategy_name,
-             locator::replication_strategy_config_options strategy_options,
-             std::optional<unsigned> initial_tablets,
-             bool durable_writes,
              std::vector<schema_ptr> cf_defs,
              user_types_metadata user_types,
              storage_options storage_opts)

--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -231,15 +231,14 @@ keyspace_metadata::new_keyspace(std::string_view name,
                                 locator::replication_strategy_config_options options,
                                 std::optional<unsigned> initial_tablets,
                                 bool durables_writes,
-                                std::vector<schema_ptr> cf_defs,
                                 storage_options storage_opts)
 {
-    return ::make_lw_shared<keyspace_metadata>(name, strategy_name, options, initial_tablets, durables_writes, cf_defs, user_types_metadata{}, storage_opts);
+    return ::make_lw_shared<keyspace_metadata>(name, strategy_name, options, initial_tablets, durables_writes, std::vector<schema_ptr>{}, user_types_metadata{}, storage_opts);
 }
 
 lw_shared_ptr<keyspace_metadata>
 keyspace_metadata::new_keyspace(const keyspace_metadata& ksm) {
-    return new_keyspace(ksm.name(), ksm.strategy_name(), ksm.strategy_options(), ksm.initial_tablets(), ksm.durable_writes(), std::vector<schema_ptr>{}, ksm.get_storage_options());
+    return new_keyspace(ksm.name(), ksm.strategy_name(), ksm.strategy_options(), ksm.initial_tablets(), ksm.durable_writes(), ksm.get_storage_options());
 }
 
 void keyspace_metadata::add_user_type(const user_type ut) {

--- a/data_dictionary/keyspace_metadata.hh
+++ b/data_dictionary/keyspace_metadata.hh
@@ -45,7 +45,7 @@ public:
                  std::string_view strategy_name,
                  locator::replication_strategy_config_options options,
                  std::optional<unsigned> initial_tablets,
-                 bool durables_writes,
+                 bool durables_writes = true,
                  std::vector<schema_ptr> cf_defs = std::vector<schema_ptr>{},
                  storage_options storage_opts = {});
     static lw_shared_ptr<keyspace_metadata>

--- a/data_dictionary/keyspace_metadata.hh
+++ b/data_dictionary/keyspace_metadata.hh
@@ -37,22 +37,9 @@ public:
                  locator::replication_strategy_config_options strategy_options,
                  std::optional<unsigned> initial_tablets,
                  bool durable_writes,
-                 std::vector<schema_ptr> cf_defs = std::vector<schema_ptr>{});
-    keyspace_metadata(std::string_view name,
-                 std::string_view strategy_name,
-                 locator::replication_strategy_config_options strategy_options,
-                 std::optional<unsigned> initial_tablets,
-                 bool durable_writes,
-                 std::vector<schema_ptr> cf_defs,
-                 user_types_metadata user_types);
-    keyspace_metadata(std::string_view name,
-                 std::string_view strategy_name,
-                 locator::replication_strategy_config_options strategy_options,
-                 std::optional<unsigned> initial_tablets,
-                 bool durable_writes,
-                 std::vector<schema_ptr> cf_defs,
-                 user_types_metadata user_types,
-                 storage_options storage_opts);
+                 std::vector<schema_ptr> cf_defs = std::vector<schema_ptr>{},
+                 user_types_metadata user_types = user_types_metadata{},
+                 storage_options storage_opts = storage_options{});
     static lw_shared_ptr<keyspace_metadata>
     new_keyspace(std::string_view name,
                  std::string_view strategy_name,

--- a/data_dictionary/keyspace_metadata.hh
+++ b/data_dictionary/keyspace_metadata.hh
@@ -46,7 +46,6 @@ public:
                  locator::replication_strategy_config_options options,
                  std::optional<unsigned> initial_tablets,
                  bool durables_writes = true,
-                 std::vector<schema_ptr> cf_defs = std::vector<schema_ptr>{},
                  storage_options storage_opts = {});
     static lw_shared_ptr<keyspace_metadata>
     new_keyspace(const keyspace_metadata& ksm);

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -2213,8 +2213,7 @@ lw_shared_ptr<keyspace_metadata> create_keyspace_from_schema_partition(const sch
             initial_tablets = row.get<int>("initial_tablets");
         }
     }
-    return make_lw_shared<keyspace_metadata>(keyspace_name, strategy_name, strategy_options, initial_tablets, durable_writes,
-            std::vector<schema_ptr>{}, data_dictionary::user_types_metadata{}, storage_opts);
+    return keyspace_metadata::new_keyspace(keyspace_name, strategy_name, strategy_options, initial_tablets, durable_writes, storage_opts);
 }
 
 template<typename V>

--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -265,8 +265,7 @@ future<> system_distributed_keyspace::start() {
                 NAME,
                 "org.apache.cassandra.locator.SimpleStrategy",
                 {{"replication_factor", "3"}},
-                std::nullopt,
-                true /* durable_writes */);
+                std::nullopt);
         if (!db.has_keyspace(NAME)) {
             mutations = service::prepare_new_keyspace_announcement(db.real_database(), sd_ksm, ts);
             description += format(" create {} keyspace;", NAME);
@@ -278,8 +277,7 @@ future<> system_distributed_keyspace::start() {
                 NAME_EVERYWHERE,
                 "org.apache.cassandra.locator.EverywhereStrategy",
                 {},
-                std::nullopt,
-                true /* durable_writes */);
+                std::nullopt);
         if (!db.has_keyspace(NAME_EVERYWHERE)) {
             auto sde_mutations = service::prepare_new_keyspace_announcement(db.real_database(), sde_ksm, ts);
             std::move(sde_mutations.begin(), sde_mutations.end(), std::back_inserter(mutations));

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2156,6 +2156,7 @@ class topology_coordinator {
                     // FIXME: nodes that cannot be reached need to be isolated either automatically or
                     // by an administrator
                     co_await sleep_abortable(_ring_delay, _as);
+                    node = retake_node(co_await start_operation(), node.id);
                 }
                 switch(node.rs->state) {
                 case node_state::bootstrapping: {
@@ -2360,6 +2361,7 @@ class topology_coordinator {
                     // Lets wait for the ring delay for those writes to complete and new topology to propagate
                     // before continuing.
                     co_await sleep_abortable(_ring_delay, _as);
+                    node = retake_node(co_await start_operation(), node.id);
                 }
 
                 // Tell the node to shut down.

--- a/table_helper.cc
+++ b/table_helper.cc
@@ -145,7 +145,7 @@ future<> table_helper::setup_keyspace(cql3::query_processor& qp, service::migrat
 
     std::map<sstring, sstring> opts;
     opts["replication_factor"] = replication_factor;
-    auto ksm = keyspace_metadata::new_keyspace(keyspace_name, "org.apache.cassandra.locator.SimpleStrategy", std::move(opts), std::nullopt, true);
+    auto ksm = keyspace_metadata::new_keyspace(keyspace_name, "org.apache.cassandra.locator.SimpleStrategy", std::move(opts), std::nullopt);
 
     while (!db.has_keyspace(keyspace_name)) {
         auto group0_guard = co_await mm.start_group0_operation();

--- a/test/boost/schema_loader_test.cc
+++ b/test/boost/schema_loader_test.cc
@@ -8,39 +8,47 @@
 
 #include "test/lib/scylla_test_case.hh"
 
+#include "db/config.hh"
 #include "tools/schema_loader.hh"
 
 SEASTAR_THREAD_TEST_CASE(test_empty) {
-    BOOST_REQUIRE_THROW(tools::load_schemas("").get(), std::exception);
-    BOOST_REQUIRE_THROW(tools::load_schemas(";").get(), std::exception);
+    db::config dbcfg;
+    BOOST_REQUIRE_THROW(tools::load_schemas(dbcfg, "").get(), std::exception);
+    BOOST_REQUIRE_THROW(tools::load_schemas(dbcfg, ";").get(), std::exception);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_keyspace_only) {
-    BOOST_REQUIRE_EQUAL(tools::load_schemas("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1};").get().size(), 0);
+    db::config dbcfg;
+    BOOST_REQUIRE_EQUAL(tools::load_schemas(dbcfg, "CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1};").get().size(), 0);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_single_table) {
-    BOOST_REQUIRE_EQUAL(tools::load_schemas("CREATE TABLE ks.cf (pk int PRIMARY KEY, v int)").get().size(), 1);
-    BOOST_REQUIRE_EQUAL(tools::load_schemas("CREATE TABLE ks.cf (pk int PRIMARY KEY, v map<int, int>)").get().size(), 1);
-    BOOST_REQUIRE_EQUAL(tools::load_schemas("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}; CREATE TABLE ks.cf (pk int PRIMARY KEY, v int);").get().size(), 1);
+    db::config dbcfg;
+    BOOST_REQUIRE_EQUAL(tools::load_schemas(dbcfg, "CREATE TABLE ks.cf (pk int PRIMARY KEY, v int)").get().size(), 1);
+    BOOST_REQUIRE_EQUAL(tools::load_schemas(dbcfg, "CREATE TABLE ks.cf (pk int PRIMARY KEY, v map<int, int>)").get().size(), 1);
+    BOOST_REQUIRE_EQUAL(tools::load_schemas(dbcfg, "CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}; CREATE TABLE ks.cf (pk int PRIMARY KEY, v int);").get().size(), 1);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_keyspace_replication_strategy) {
-    BOOST_REQUIRE_EQUAL(tools::load_schemas("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}; CREATE TABLE ks.cf (pk int PRIMARY KEY, v int);").get().size(), 1);
-    BOOST_REQUIRE_EQUAL(tools::load_schemas("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}; CREATE TABLE ks.cf (pk int PRIMARY KEY, v int);").get().size(), 1);
-    BOOST_REQUIRE_EQUAL(tools::load_schemas("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'mydc1': 1, 'mydc2': 4}; CREATE TABLE ks.cf (pk int PRIMARY KEY, v int);").get().size(), 1);
+    db::config dbcfg;
+    BOOST_REQUIRE_EQUAL(tools::load_schemas(dbcfg, "CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}; CREATE TABLE ks.cf (pk int PRIMARY KEY, v int);").get().size(), 1);
+    BOOST_REQUIRE_EQUAL(tools::load_schemas(dbcfg, "CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}; CREATE TABLE ks.cf (pk int PRIMARY KEY, v int);").get().size(), 1);
+    BOOST_REQUIRE_EQUAL(tools::load_schemas(dbcfg, "CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'mydc1': 1, 'mydc2': 4}; CREATE TABLE ks.cf (pk int PRIMARY KEY, v int);").get().size(), 1);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_multiple_tables) {
-    BOOST_REQUIRE_EQUAL(tools::load_schemas("CREATE TABLE ks.cf1 (pk int PRIMARY KEY, v int); CREATE TABLE ks.cf2 (pk int PRIMARY KEY, v int)").get().size(), 2);
-    BOOST_REQUIRE_EQUAL(tools::load_schemas("CREATE TABLE ks.cf1 (pk int PRIMARY KEY, v int); CREATE TABLE ks.cf2 (pk int PRIMARY KEY, v int);").get().size(), 2);
+    db::config dbcfg;
+    BOOST_REQUIRE_EQUAL(tools::load_schemas(dbcfg, "CREATE TABLE ks.cf1 (pk int PRIMARY KEY, v int); CREATE TABLE ks.cf2 (pk int PRIMARY KEY, v int)").get().size(), 2);
+    BOOST_REQUIRE_EQUAL(tools::load_schemas(dbcfg, "CREATE TABLE ks.cf1 (pk int PRIMARY KEY, v int); CREATE TABLE ks.cf2 (pk int PRIMARY KEY, v int);").get().size(), 2);
     BOOST_REQUIRE_EQUAL(tools::load_schemas(
+                dbcfg,
                 "CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}; "
                 "CREATE TABLE ks.cf1 (pk int PRIMARY KEY, v int); "
                 "CREATE TABLE ks.cf2 (pk int PRIMARY KEY, v int); "
                 "CREATE TABLE ks.cf3 (pk int PRIMARY KEY, v int); "
     ).get().size(), 3);
     BOOST_REQUIRE_EQUAL(tools::load_schemas(
+                dbcfg,
                 "CREATE KEYSPACE ks1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}; "
                 "CREATE TABLE ks1.cf (pk int PRIMARY KEY, v int); "
                 "CREATE KEYSPACE ks2 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}; "
@@ -49,17 +57,21 @@ SEASTAR_THREAD_TEST_CASE(test_multiple_tables) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_udts) {
+    db::config dbcfg;
     BOOST_REQUIRE_EQUAL(tools::load_schemas(
+                dbcfg,
                 "CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}; "
                 "CREATE TYPE ks.type1 (f1 int, f2 text); "
                 "CREATE TABLE ks.cf (pk int PRIMARY KEY, v frozen<type1>); "
     ).get().size(), 1);
     BOOST_REQUIRE_EQUAL(tools::load_schemas(
+                dbcfg,
                 "CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}; "
                 "CREATE TYPE ks.type1 (f1 int, f2 text); "
                 "CREATE TABLE ks.cf (pk int PRIMARY KEY, v type1); "
     ).get().size(), 1);
     BOOST_REQUIRE_EQUAL(tools::load_schemas(
+                dbcfg,
                 "CREATE KEYSPACE ks1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}; "
                 "CREATE TYPE ks1.type1 (f1 int, f2 text); "
                 "CREATE TABLE ks1.cf (pk int PRIMARY KEY, v frozen<type1>); "
@@ -68,10 +80,12 @@ SEASTAR_THREAD_TEST_CASE(test_udts) {
                 "CREATE TABLE ks2.cf (pk int PRIMARY KEY, v frozen<type1>); "
     ).get().size(), 2);
     BOOST_REQUIRE_EQUAL(tools::load_schemas(
+                dbcfg,
                 "CREATE TYPE ks.type1 (f1 int, f2 text); "
                 "CREATE TABLE ks.cf (pk int PRIMARY KEY, v frozen<type1>); "
     ).get().size(), 1);
     BOOST_REQUIRE_EQUAL(tools::load_schemas(
+                dbcfg,
                 "CREATE TYPE ks1.type1 (f1 int, f2 text); "
                 "CREATE TABLE ks1.cf (pk int PRIMARY KEY, v frozen<type1>); "
                 "CREATE TYPE ks2.type1 (f1 int, f2 text); "
@@ -80,27 +94,34 @@ SEASTAR_THREAD_TEST_CASE(test_udts) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_dropped_columns) {
+    db::config dbcfg;
     BOOST_REQUIRE_EQUAL(tools::load_schemas(
+                dbcfg,
                 "CREATE TABLE ks.cf (pk int PRIMARY KEY, v1 int); "
                 "INSERT INTO system_schema.dropped_columns (keyspace_name, table_name, column_name, dropped_time, type) VALUES ('ks', 'cf', 'v2', 1631011979170675, 'int'); "
     ).get().size(), 1);
     BOOST_REQUIRE_THROW(tools::load_schemas(
+                dbcfg,
                 "CREATE TABLE ks.cf (pk int PRIMARY KEY, v1 int); "
                 "INSERT INTO ks.cf (pk, v1) VALUES (0, 0); "
     ).get(), std::exception);
     BOOST_REQUIRE_THROW(tools::load_schemas(
+                dbcfg,
                 "INSERT INTO system_schema.dropped_columns (keyspace_name, table_name, column_name, dropped_time, type) VALUES ('ks', 'cf', 'v2', 1631011979170675, 'int'); "
                 "CREATE TABLE ks.cf (pk int PRIMARY KEY, v1 int); "
     ).get(), std::exception);
     BOOST_REQUIRE_THROW(tools::load_schemas(
+                dbcfg,
                 "CREATE TABLE ks.cf (pk int PRIMARY KEY, v1 int); "
                 "INSERT INTO system_schema.dropped_columns (keyspace_name, table_name, column_name, dropped_time, type) VALUES ('unknown_ks', 'unknown_cf', 'v2', 1631011979170675, 'int'); "
     ).get(), std::exception);
     BOOST_REQUIRE_THROW(tools::load_schemas(
+                dbcfg,
                 "CREATE TABLE ks.cf (pk int PRIMARY KEY, v1 int); "
                 "INSERT INTO system_schema.dropped_columns (keyspace_name, table_name, column_name, dropped_time, type) VALUES ('unknown_ks', 'cf', 'v2', 1631011979170675, 'int'); "
     ).get(), std::exception);
     BOOST_REQUIRE_THROW(tools::load_schemas(
+                dbcfg,
                 "CREATE TABLE ks.cf (pk int PRIMARY KEY, v1 int); "
                 "INSERT INTO system_schema.dropped_columns (keyspace_name, table_name, column_name, dropped_time, type) VALUES ('ks', 'unknown_cf', 'v2', 1631011979170675, 'int'); "
     ).get(), std::exception);

--- a/test/lib/expr_test_utils.cc
+++ b/test/lib/expr_test_utils.cc
@@ -497,12 +497,12 @@ class mock_database_impl : public data_dictionary::impl {
 public:
     explicit mock_database_impl(schema_ptr table_schema)
         : _table_schema(table_schema),
-          _keyspace_metadata(data_dictionary::keyspace_metadata::new_keyspace(_table_schema->ks_name(),
+          _keyspace_metadata(make_lw_shared<data_dictionary::keyspace_metadata>(_table_schema->ks_name(),
                                                                               "MockReplicationStrategy",
-                                                                              {},
-                                                                              {},
+                                                                              locator::replication_strategy_config_options{},
+                                                                              std::nullopt,
                                                                               false,
-                                                                              {_table_schema})) {}
+                                                                              std::vector<schema_ptr>({_table_schema}))) {}
 
     static std::pair<data_dictionary::database, std::unique_ptr<mock_database_impl>> make(schema_ptr table_schema) {
         std::unique_ptr<mock_database_impl> mock_db = std::make_unique<mock_database_impl>(table_schema);

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -49,12 +49,12 @@ struct table;
 
 struct database {
     db::extensions extensions;
-    db::config& cfg;
+    const db::config& cfg;
     gms::feature_service& features;
     std::list<keyspace> keyspaces;
     std::list<table> tables;
 
-    database(db::config& cfg, gms::feature_service& features) : cfg(cfg), features(features)
+    database(const db::config& cfg, gms::feature_service& features) : cfg(cfg), features(features)
     { }
 };
 
@@ -209,12 +209,8 @@ sstring read_file(std::filesystem::path path) {
     return util::read_entire_stream_contiguous(fstream).get();
 }
 
-std::vector<schema_ptr> do_load_schemas(std::string_view schema_str) {
+std::vector<schema_ptr> do_load_schemas(const db::config& cfg, std::string_view schema_str) {
     cql3::cql_stats cql_stats;
-
-    db::config cfg;
-    cfg.enable_cache(false);
-    cfg.volatile_system_keyspace_for_testing(true);
 
     gms::feature_service feature_service(gms::feature_config_from_db_config(cfg));
     feature_service.enable(feature_service.supported_feature_set()).get();
@@ -335,13 +331,12 @@ std::vector<schema_ptr> do_load_schemas(std::string_view schema_str) {
 
 struct sstable_manager_service {
     db::nop_large_data_handler large_data_handler;
-    db::config dbcfg;
     gms::feature_service feature_service;
     cache_tracker tracker;
     sstables::directory_semaphore dir_sem;
     sstables::sstables_manager sst_man;
 
-    explicit sstable_manager_service()
+    explicit sstable_manager_service(const db::config& dbcfg)
         : feature_service(gms::feature_config_from_db_config(dbcfg))
         , dir_sem(1)
         , sst_man("schema_loader", large_data_handler, dbcfg, feature_service, tracker, memory::stats().total_memory(), dir_sem, []{ return locator::host_id{}; }) {
@@ -518,12 +513,12 @@ std::unordered_map<schema_ptr, std::string> get_schema_table_directories(std::fi
     return schema_table_table_dir;
 }
 
-schema_ptr do_load_schema_from_schema_tables(std::filesystem::path scylla_data_path, std::string_view keyspace, std::string_view table) {
+schema_ptr do_load_schema_from_schema_tables(const db::config& dbcfg, std::filesystem::path scylla_data_path, std::string_view keyspace, std::string_view table) {
     reader_concurrency_semaphore rcs_sem(reader_concurrency_semaphore::no_limits{}, __FUNCTION__, reader_concurrency_semaphore::register_metrics::no);
     auto stop_semaphore = deferred_stop(rcs_sem);
 
     sharded<sstable_manager_service> sst_man;
-    sst_man.start().get();
+    sst_man.start(std::ref(dbcfg)).get();
     auto stop_sst_man_service = deferred_stop(sst_man);
 
     auto schema_table_table_dir = get_schema_table_directories(scylla_data_path);
@@ -584,7 +579,6 @@ schema_ptr do_load_schema_from_schema_tables(std::filesystem::path scylla_data_p
         }
     }
 
-    db::config dbcfg;
     auto user_type_storage = std::make_shared<single_keyspace_user_types_storage>(std::move(utm));
     gms::feature_service features(gms::feature_config_from_db_config(dbcfg));
     db::schema_ctxt ctxt(dbcfg, user_type_storage, features);
@@ -598,15 +592,15 @@ schema_ptr do_load_schema_from_schema_tables(std::filesystem::path scylla_data_p
 
 namespace tools {
 
-future<std::vector<schema_ptr>> load_schemas(std::string_view schema_str) {
-    return async([schema_str] () mutable {
-        return do_load_schemas(schema_str);
+future<std::vector<schema_ptr>> load_schemas(const db::config& dbcfg, std::string_view schema_str) {
+    return async([&dbcfg, schema_str] () mutable {
+        return do_load_schemas(dbcfg, schema_str);
     });
 }
 
-future<schema_ptr> load_one_schema_from_file(std::filesystem::path path) {
-    return async([path] () mutable {
-        auto schemas = do_load_schemas(read_file(path));
+future<schema_ptr> load_one_schema_from_file(const db::config& dbcfg, std::filesystem::path path) {
+    return async([&dbcfg, path] () mutable {
+        auto schemas = do_load_schemas(dbcfg, read_file(path));
         if (schemas.size() != 1) {
             throw std::runtime_error(fmt::format("Schema file {} expected to contain exactly 1 schema, actually has {}", path.native(), schemas.size()));
         }
@@ -614,9 +608,7 @@ future<schema_ptr> load_one_schema_from_file(std::filesystem::path path) {
     });
 }
 
-schema_ptr load_system_schema(std::string_view keyspace, std::string_view table) {
-    db::config cfg;
-    cfg.experimental_features.set(db::experimental_features_t::all());
+schema_ptr load_system_schema(const db::config& cfg, std::string_view keyspace, std::string_view table) {
     const std::unordered_map<std::string_view, std::vector<schema_ptr>> schemas{
         {db::schema_tables::NAME, db::schema_tables::all_tables(db::schema_features::full())},
         {db::system_keyspace::NAME, db::system_keyspace::all_tables(cfg)},
@@ -636,9 +628,9 @@ schema_ptr load_system_schema(std::string_view keyspace, std::string_view table)
     return *tb_it;
 }
 
-future<schema_ptr> load_schema_from_schema_tables(std::filesystem::path scylla_data_path, std::string_view keyspace, std::string_view table) {
-    return async([=] () mutable {
-        return do_load_schema_from_schema_tables(scylla_data_path, keyspace, table);
+future<schema_ptr> load_schema_from_schema_tables(const db::config& cfg, std::filesystem::path scylla_data_path, std::string_view keyspace, std::string_view table) {
+    return async([=, &cfg] () mutable {
+        return do_load_schema_from_schema_tables(cfg, scylla_data_path, keyspace, table);
     });
 }
 

--- a/tools/schema_loader.hh
+++ b/tools/schema_loader.hh
@@ -12,6 +12,10 @@
 #include "seastarx.hh"
 #include "schema/schema.hh"
 
+namespace db {
+class config;
+}
+
 namespace tools {
 
 /// Load the schema(s) from the specified string
@@ -28,13 +32,13 @@ namespace tools {
 ///
 /// [1] Currently some global services has to be instantiated (snitch) to
 /// be able to load the schema(s), these survive the call.
-future<std::vector<schema_ptr>> load_schemas(std::string_view schema_str);
+future<std::vector<schema_ptr>> load_schemas(const db::config& dbcfg, std::string_view schema_str);
 
 /// Load exactly one schema from the specified path
 ///
 /// If the file at the specified path contains more or less then one schema,
 /// an exception will be thrown. See \ref load_schemas().
-future<schema_ptr> load_one_schema_from_file(std::filesystem::path path);
+future<schema_ptr> load_one_schema_from_file(const db::config& dbcfg, std::filesystem::path path);
 
 /// Load the system schema, with the given keyspace and table
 ///
@@ -47,7 +51,7 @@ future<schema_ptr> load_one_schema_from_file(std::filesystem::path path);
 ///
 /// Any table from said keyspaces can be loaded. The keyspaces are created with
 /// all schema and experimental features enabled.
-schema_ptr load_system_schema(std::string_view keyspace, std::string_view table);
+schema_ptr load_system_schema(const db::config& dbcfg, std::string_view keyspace, std::string_view table);
 
 /// Load the schema of the table with the designated keyspace and table name,
 /// from the system schema table sstables.
@@ -56,6 +60,6 @@ schema_ptr load_system_schema(std::string_view keyspace, std::string_view table)
 /// tries very hard to have no side-effects.
 /// The \p scylla_data_path parameter is expected to point to the scylla data
 /// directory, which is usually /var/lib/scylla/data.
-future<schema_ptr> load_schema_from_schema_tables(std::filesystem::path scylla_data_path, std::string_view keyspace, std::string_view table);
+future<schema_ptr> load_schema_from_schema_tables(const db::config& dbcfg, std::filesystem::path scylla_data_path, std::string_view keyspace, std::string_view table);
 
 } // namespace tools


### PR DESCRIPTION
test.py inherits its env from the user, which is the right thing:
some python modules, e.g. logging, do accept env-based configuration.
    
However, test.py also starts subprocesses, i.e. tests, which start
other subprocesses, e.g. scylladb instances. And when the instance
is started without an explicit configuration file, SCYLLA_CONF from
user environment can be used.
    
If this scylla.conf contains funny parameters, e.g. unsupported
configuration options, the tests may break in an unexpected way.
    
Avoid that by overriding the env in all scylla subprocess invocations
(test/pylib/scylla_cluster.py is already clean in that regard).
    
Fixes all the patched tests on my machine.
